### PR TITLE
Some small tidies to view.js

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -107,7 +107,7 @@ const rootPaddingLeft = bodyStyles
 	.getPropertyValue( '--wp--style--root--padding-left' )
 	.trim();
 const rootPaddingRight = bodyStyles
-	.getPropertyValue( '--wp--style--root--padding-left' )
+	.getPropertyValue( '--wp--style--root--padding-right' )
 	.trim();
 
 function adjustMegaMenus() {

--- a/src/view.js
+++ b/src/view.js
@@ -218,6 +218,11 @@ if ( document.readyState === 'complete' ) {
 
 // Function to convert a complex CSS value to pixels
 function convertCssValueToPixels( cssValue ) {
+	// If there is no value to convert, return zero.
+	if ( ! cssValue ) {
+		return 0;
+	}
+	
 	// Create a temporary element
 	const tempElement = document.createElement( 'div' );
 


### PR DESCRIPTION
Correcting one property snag where it's getting left when it seems like it should be right, as well as handling an error case where the css value to be converted is false-y (null, or empty string) -- that happened to me in some local testing and was an important addition.